### PR TITLE
Add support for composite USB devices

### DIFF
--- a/src/devices/mouse.c
+++ b/src/devices/mouse.c
@@ -85,45 +85,54 @@ uint8_t Mouse_attach(InputDevice *c, int device_id, int port)
 #if defined(DEBUG)
       ksceDebugPrintf("opening in pipe\n");
 #endif
-      c->pipe_in = ksceUsbdOpenPipe(device_id, endpoint);
-#if defined(DEBUG)
-      ksceDebugPrintf("= 0x%08x\n", c->pipe_in);
-      ksceDebugPrintf("bmAttributes = %x\n", endpoint->bmAttributes);
-#endif
       c->buffer_size = endpoint->wMaxPacketSize;
       if (c->buffer_size > 64)
       {
         ksceDebugPrintf("Packet size too big = %d\n", endpoint->wMaxPacketSize);
         return 0;
       }
-    }
-    if (c->pipe_in > 0)
+      c->pipe_in = ksceUsbdOpenPipe(device_id, endpoint);
+#if defined(DEBUG)
+      ksceDebugPrintf("= 0x%08x\n", c->pipe_in);
+      ksceDebugPrintf("bmAttributes = %x\n", endpoint->bmAttributes);
+#endif
       break;
+    }
     endpoint
         = (SceUsbdEndpointDescriptor *)ksceUsbdScanStaticDescriptor(device_id, endpoint, SCE_USBD_DESCRIPTOR_ENDPOINT);
   }
 
-  if (c->pipe_in > 0)
+  if (!c->pipe_in)
+    return 0;
+
+  SceUsbdConfigurationDescriptor *cdesc;
+  if ((cdesc = (SceUsbdConfigurationDescriptor *)ksceUsbdScanStaticDescriptor(device_id, NULL,
+                                                                              SCE_USBD_DESCRIPTOR_CONFIGURATION))
+      == NULL)
   {
-    SceUsbdConfigurationDescriptor *cdesc;
-    if ((cdesc = (SceUsbdConfigurationDescriptor *)ksceUsbdScanStaticDescriptor(device_id, NULL,
-                                                                                SCE_USBD_DESCRIPTOR_CONFIGURATION))
-        == NULL)
-      return 0;
-
-    SceUID control_pipe_id = ksceUsbdOpenPipe(device_id, NULL);
-    c->pipe_control        = control_pipe_id;
-    // set default config
-    int r = ksceUsbdSetConfiguration(control_pipe_id, cdesc->bConfigurationValue, mouse_cfg_done, c);
-#if defined(DEBUG)
-    ksceDebugPrintf("ksceUsbdSetConfiguration = 0x%08x\n", r);
-#endif
-    if (r < 0)
-      return 0;
-
-    c->attached = 1;
-    c->inited   = 1;
+    ksceUsbdClosePipe(c->pipe_in);
+    c->pipe_in = 0;
+    return 0;
   }
+
+  SceUID control_pipe_id = ksceUsbdOpenPipe(device_id, NULL);
+  c->pipe_control        = control_pipe_id;
+  // set default config
+  int r = ksceUsbdSetConfiguration(control_pipe_id, cdesc->bConfigurationValue, mouse_cfg_done, c);
+#if defined(DEBUG)
+  ksceDebugPrintf("ksceUsbdSetConfiguration = 0x%08x\n", r);
+#endif
+  if (r < 0)
+  {
+    ksceUsbdClosePipe(c->pipe_control);
+    c->pipe_control = 0;
+    ksceUsbdClosePipe(c->pipe_in);
+    c->pipe_in = 0;
+    return 0;
+  }
+
+  c->attached = 1;
+  c->inited   = 1;
 
   usb_read(c);
   return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -179,6 +179,7 @@ int libtvikey_probe(int device_id)
 
 int libtvikey_attach(int device_id)
 {
+  int status = SCE_USBD_ATTACH_FAILED;
   SceUsbdDeviceDescriptor *device;
   ksceDebugPrintf("attaching device: %x\n", device_id);
   device = (SceUsbdDeviceDescriptor *)ksceUsbdScanStaticDescriptor(device_id, 0, SCE_USBD_DESCRIPTOR_DEVICE);
@@ -187,7 +188,7 @@ int libtvikey_attach(int device_id)
     ksceDebugPrintf("vendor: %04x\n", device->idVendor);
     ksceDebugPrintf("product: %04x\n", device->idProduct);
     int i;
-
+    for (int type = MOUSE; type <= KEYBOARD; type++)
     {
       int cont = -1;
 
@@ -202,40 +203,64 @@ int libtvikey_attach(int device_id)
       }
 
       if (cont == -1)
-        return SCE_USBD_ATTACH_FAILED;
+        break;
 
       if (!devices[cont].attached)
       {
-        if (Mouse_attach(&devices[cont], device_id, cont))
+        switch (type)
         {
-          // something gone wrong during usb init
-          if (!devices[cont].inited)
-          {
-            ksceDebugPrintf("Can't init mouse\n");
-            return SCE_USBD_ATTACH_FAILED;
-          }
-          ksceDebugPrintf("Attached!\n");
-          return SCE_USBD_ATTACH_SUCCEEDED;
-        }
-        else if (Keyboard_attach(&devices[cont], device_id, cont))
-        {
-          // something gone wrong during usb init
-          if (!devices[cont].inited)
-          {
-            ksceDebugPrintf("Can't init kb\n");
-            return SCE_USBD_ATTACH_FAILED;
-          }
-          ksceDebugPrintf("Attached!\n");
-          return SCE_USBD_ATTACH_SUCCEEDED;
+          case MOUSE:
+            if (Mouse_attach(&devices[cont], device_id, cont))
+            {
+              // something gone wrong during usb init
+              if (!devices[cont].inited)
+              {
+                ksceDebugPrintf("Can't init mouse\n");
+              }
+              else
+              {
+                ksceDebugPrintf("Attached mouse!\n");
+                status = SCE_USBD_ATTACH_SUCCEEDED;
+                // loop to next device type and find next slot
+                continue;
+              }
+            }
+
+            // try next device type on this slot
+            type++;
+            // fallthrough
+          case KEYBOARD:
+            if (Keyboard_attach(&devices[cont], device_id, cont))
+            {
+              // something gone wrong during usb init
+              if (!devices[cont].inited)
+              {
+                ksceDebugPrintf("Can't init kb\n");
+              }
+              else
+              {
+                ksceDebugPrintf("Attached kb!\n");
+                status = SCE_USBD_ATTACH_SUCCEEDED;
+                // loop to next device type and find next slot
+                continue;
+              }
+            }
+
+            // try next device type on this slot
+            type++;
+            // fallthrough
+          default:
+            break;
         }
       }
     }
   }
-  return SCE_USBD_ATTACH_FAILED;
+  return status;
 }
 
 int libtvikey_detach(int device_id)
 {
+  int status = SCE_USBD_DETACH_FAILED;
 
   for (int i = 0; i < MAX_DEVICES; i++)
   {
@@ -246,11 +271,11 @@ int libtvikey_detach(int device_id)
       devices[i].pipe_in      = 0;
       devices[i].pipe_out     = 0;
       devices[i].pipe_control = 0;
-      return SCE_USBD_DETACH_SUCCEEDED;
+      status = SCE_USBD_DETACH_SUCCEEDED;
     }
   }
 
-  return SCE_USBD_DETACH_FAILED;
+  return status;
 }
 
 static int libtvikey_sysevent_handler(int resume, int eventid, void *args, void *opt)

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@
 #include <psp2kern/kernel/suspend.h>
 #include <psp2kern/kernel/sysclib.h>
 #include <psp2kern/kernel/sysroot.h>
-#include <psp2kern/sblaimgr.h>
+#include <psp2kern/kernel/aimgr.h>
 #include <psp2kern/usbd.h>
 #include <psp2kern/usbserv.h>
 #include <taihen.h>

--- a/src/util/ini.c
+++ b/src/util/ini.c
@@ -26,7 +26,7 @@ Copyright (C) 2023, Cat
 
 #include <psp2kern/io/fcntl.h>
 #include <psp2kern/kernel/debug.h>
-#include <psp2kern/kernel/sysclib.h>
+//#include <psp2kern/kernel/sysclib.h>
 
 char *scefgets(char *s, int n, SceUID iop)
 {


### PR DESCRIPTION
This change allows both a mouse and keyboard to be attached from a single USB device. Tested to work with a Logitech K400+ USB dongle (as in #2 ), which previously only worked as a mouse.